### PR TITLE
ON ERROR, HTTP 200 response is now a HTTP 500 response

### DIFF
--- a/src/example-site/lib/rxq.xqy
+++ b/src/example-site/lib/rxq.xqy
@@ -266,5 +266,6 @@ declare function rxq:resource-functions() as element(rxq:resource-functions){
  : @returns html error response
  :)    
 declare function rxq:handle-error($e){
+  xdmp:set-response-code(500, $e/error:format-string),
   rest:report-error($e)
 };

--- a/src/xquery/lib/rxq.xqy
+++ b/src/xquery/lib/rxq.xqy
@@ -266,5 +266,6 @@ declare function rxq:resource-functions() as element(rxq:resource-functions){
  : @returns html error response
  :)    
 declare function rxq:handle-error($e){
+  xdmp:set-response-code(500, $e/error:format-string),
   rest:report-error($e)
 };


### PR DESCRIPTION
When RXQ produces errors, HTTP responses now come with a HTTP 500 status code message instead of a HTTP 200 status code message, which may confuse the client.
